### PR TITLE
Added emits option to prevent warnings

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -7,6 +7,7 @@ import {
   getValidSortableEntries
 } from "./core/componentBuilderHelper";
 import { computeComponentStructure } from "./core/renderHelper";
+import { events } from "./core/sortableEvents";
 import { h, defineComponent, nextTick } from "vue";
 
 function emit(evtName, evtData) {
@@ -67,7 +68,11 @@ const props = {
   }
 };
 
-const emits = ["change", "start", "add", "remove", "update", "end", "choose", "unchoose", "sort", "filter", "clone"];
+const emits = [
+  "update:modelValue",
+  "change",
+  ...[...events.manageAndEmit, ...events.emit].map(evt => evt.toLowerCase())
+];
 
 const draggableComponent = defineComponent({
   name: "draggable",

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -67,12 +67,16 @@ const props = {
   }
 };
 
+const emits = ["change", "start", "add", "remove", "update", "end", "choose", "unchoose", "sort", "filter", "clone"];
+
 const draggableComponent = defineComponent({
   name: "draggable",
 
   inheritAttrs: false,
 
   props,
+
+  emits,
 
   data() {
     return {


### PR DESCRIPTION
When using this library in my app, I'm getting a lot of warnings from Vue that look like this:

```
[Vue warn]: Component emitted event "choose" but it is neither declared in the emits option nor as an "onChoose" prop.
```

I've added all of the emitted events I can find to the `emits` option which removes the warning.