### PR TITLE
bugfix

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -165,6 +165,7 @@ const draggableComponent = defineComponent({
     $attrs: {
       handler(newOptionValue) {
         const { _sortable } = this;
+        if (!_sortable) return;
         getValidSortableEntries(newOptionValue).forEach(([key, value]) => {
           _sortable.option(key, value);
         });


### PR DESCRIPTION
when `$attrs` is updated before mounted, throw: **Uncaught (in promise) TypeError: Cannot read property 'option' of undefined.** Because the variable ` _sortable ` has not been initialized.