### PR TITLE
Expand isHtmlAttribute

### DIFF
--- a/src/util/tags.js
+++ b/src/util/tags.js
@@ -127,7 +127,7 @@ function isTransition(name) {
 }
 
 function isHtmlAttribute(value) {
-  return ["id", "class"].includes(value) || value.startsWith("data-");
+  return ["id", "class", "role"].includes(value) || value.startsWith("data-") || value.startsWith("aria-");
 }
 
 export { isHtmlTag, isHtmlAttribute, isTransition };

--- a/tests/unit/util/tags.spec.js
+++ b/tests/unit/util/tags.spec.js
@@ -1,4 +1,4 @@
-import { isHtmlTag, isTransition } from "@/util/tags";
+import { isHtmlTag, isTransition, isHtmlAttribute } from "@/util/tags";
 
 describe("isHtmlTag", () => {
   test.each([
@@ -12,6 +12,25 @@ describe("isHtmlTag", () => {
     "for %s returns %s",
     (value, expected) =>{
       const actual = isHtmlTag(value);
+      expect(actual).toEqual(expected);
+    }
+  )
+});
+
+describe("isHtmlAttribute", () => {
+  test.each([
+    ["class", true],
+    ["id", true],
+    ["role", true],
+    ["data-whatever", true],
+    ["aria-whatever", true],
+    ["notattribute", false],
+    ["href", false],
+    ["name", false],
+  ])(
+    "for %s returns %s",
+    (value, expected) =>{
+      const actual = isHtmlAttribute(value);
       expect(actual).toEqual(expected);
     }
   )


### PR DESCRIPTION
I'm using Vue draggable in a context that would benefit from the list having `role` and some `aria-` attributes. I expanded `isHtmlAttribute` criteria to return true on those, and added some test coverage as well.