### PR TITLE
fix: Avoid crashing when updated triggered before rendering

### DIFF
--- a/src/core/componentStructure.js
+++ b/src/core/componentStructure.js
@@ -30,7 +30,7 @@ class ComponentStructure {
   updated() {
     const { defaultNodes, realList } = this;
     defaultNodes.forEach((node, index) => {
-      addContext(getHtmlElementFromNode(node), {
+      addContext(getHtmlElementFromNode(node) || {}, {
         element: realList[index],
         index
       });

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -139,7 +139,7 @@ const draggableComponent = defineComponent({
   },
 
   updated() {
-    this.componentStructure.updated();
+    this.$nextTick(() => this.componentStructure.updated());
   },
 
   beforeUnmount() {


### PR DESCRIPTION
This fixes an error that occurs when the list is first rendered empty: in some cases, upon adding the first item, it will not be rendered yet, therefore `_ref.el` will be `null` when it is checked and this crashes the lib.