### PR TITLE
Fix for issue 34, switched this.$el with evt.from

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -248,7 +248,7 @@ const draggableComponent = defineComponent({
     },
 
     onDragRemove(evt) {
-      insertNodeAt(this.$el, evt.item, evt.oldIndex);
+      insertNodeAt(evt.from, evt.item, evt.oldIndex);
       if (evt.pullMode === "clone") {
         removeNode(evt.clone);
         return;


### PR DESCRIPTION
onDragUpdate was updated to use evt.from to call insertNodeAt, but onDragRemove was not updated accordingly.

This pull request simply corrects this slight oversight, fixing a crash I was experiencing.