### PR TITLE
Add `compatConfig` to draggableComponent

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -78,6 +78,8 @@ const draggableComponent = defineComponent({
   name: "draggable",
 
   inheritAttrs: false,
+  
+  compatConfig: { MODE: 3 },
 
   props,
 


### PR DESCRIPTION
Closes #57. The `Draggable` component is designed to work under vue 3, but because it doesn't provide a local `compatConfig` override, applications using `@vue/compat` will render the component in whatever compatibility mode the host application has been set to. In particular, things like `INSTANCE_SCOPED_SLOTS` and `RENDER_FUNCTION` will cause invocations of `this.$slots.item(props)` to invoke the item slot without props (to maintain the legacy meaning of invoking a `$slot`), which will crash. 

We can configure the component to indicate that it is fully Vue 3 compatible so that it "just works" for folks using the compatibility build.