### PR TITLE
fix comment being rendered as a node from item slot

### DIFF
--- a/src/core/renderHelper.js
+++ b/src/core/renderHelper.js
@@ -17,7 +17,7 @@ function computeNodes({ $slots, realList, getKey }) {
     throw new Error("draggable element must have an item slot");
   }
   const defaultNodes = normalizedList.flatMap((element, index) =>
-    item({ element, index }).map(node => {
+    item({ element, index }).filter((node) => String(node.type) !== "Symbol(Comment)").map(node => {
       node.key = getKey(element);
       node.props = { ...(node.props || {}), "data-draggable": true };
       return node;


### PR DESCRIPTION
I had the following problem:

![image](https://user-images.githubusercontent.com/49000408/190429576-b676413a-a796-4e8c-804d-f2fd56a65796.png)

![image](https://user-images.githubusercontent.com/49000408/190430334-2e502326-4120-4b1c-becc-ce9acf77f6a4.png)

Debugging the library on node_modules I found out that the comment nodes are being rendered as a valid element, and I think it shouldn't. Sometimes in development we need to test something and for that we're going to comment the code.
