### PR TITLE
Removed cancel example from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ checkMove: function(evt){
     return (evt.draggedContext.element.name!=='apple');
 }
 ```
-See complete example: [Cancel.html](https://github.com/SortableJS/Vue.Draggable/blob/master/examples/Cancel.html), [cancel.js](https://github.com/SortableJS/Vue.Draggable/blob/master/examples/script/cancel.js)
 
 #### componentData
 Type: `Object`<br>


### PR DESCRIPTION
As the examples/Cancel.html and the corresponding JS files don't exist (anymore?), those files shouldn't be mentioned in the ReadME.