### PR TITLE
fix #140 empty context

### DIFF
--- a/src/core/componentStructure.js
+++ b/src/core/componentStructure.js
@@ -1,4 +1,9 @@
-const getHtmlElementFromNode = ({ el }) => el;
+const getHtmlElementFromNode = (node) => {
+  const el =
+      node.el || (Array.isArray(node.children) && node.children[0].el.parentNode);
+  return el || {};
+};
+
 const addContext = (domElement, context) =>
   (domElement.__draggable_context = context);
 const getContext = domElement => domElement.__draggable_context;


### PR DESCRIPTION
Fix empty node element:
`
Uncaught (in promise) TypeError: Cannot set properties of null (setting '__draggable_context')
`
Simple error handler
```
const getHtmlElementFromNode = (node) => {
  const el =
      node.el || (Array.isArray(node.children) && node.children[0].el.parentNode);
  return el || {};
};
```