### PR TITLE
Add margin style in component to improve clarity

### DIFF
--- a/example/components/infra/nested.vue
+++ b/example/components/infra/nested.vue
@@ -35,4 +35,7 @@ export default {
   min-height: 50px;
   outline: 1px dashed;
 }
+li {
+  margin-left: 1em;
+}
 </style>


### PR DESCRIPTION
Change: Added minor styling in the component to show margins for each nested layer. Adding this necessary style to the component definition makes things neater.

Experience: I copied the example and had to work to discover why the li has no margin.