### PR TITLE
Update repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "types/vuedraggable.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SortableJS/Vue.Draggable.git"
+    "url": "https://github.com/SortableJS/vue.draggable.next.git"
   },
   "private": false,
   "scripts": {


### PR DESCRIPTION
My IDE was reporting that the latest version of this package was 2.x.x . This was because the URL was pointing to the vue2 repo.