### PR TITLE
Pass index as second argument of getKey function

### DIFF
--- a/src/core/renderHelper.js
+++ b/src/core/renderHelper.js
@@ -18,7 +18,7 @@ function computeNodes({ $slots, realList, getKey }) {
   }
   const defaultNodes = normalizedList.flatMap((element, index) =>
     item({ element, index }).map(node => {
-      node.key = getKey(element);
+      node.key = getKey(element, index);
       node.props = { ...(node.props || {}), "data-draggable": true };
       return node;
     })


### PR DESCRIPTION
It is necessary to deal with elements that don't have `id`